### PR TITLE
keep all text localy until body evaluation

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
@Truba  this is what I was talking about on Slack the other day. It was a bit hard to explain so I wanted to show it in code. This way even after we change the language all concatenated texts will be properly re-calculated