### PR TITLE
Feature/add privacy manifest

### DIFF
--- a/Example/SwiftI18n.xcodeproj/project.pbxproj
+++ b/Example/SwiftI18n.xcodeproj/project.pbxproj
@@ -482,7 +482,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 5F5M64F878;
 				INFOPLIST_FILE = SwiftI18n/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-D\" \"CASE\"";
@@ -498,7 +498,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 5F5M64F878;
 				INFOPLIST_FILE = SwiftI18n/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MODULE_NAME = ExampleApp;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-D\" \"CASE\"";
@@ -518,7 +518,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -533,7 +533,7 @@
 				DEVELOPMENT_TEAM = 5F5M64F878;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cocoapods.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
     .target(
         name: "SwiftI18n",
         path: "SwiftI18n",
-        sources: ["./Classes/Main/", "./Classes/Case/", "./Classes/Views/BaseViews/", "./Classes/Views/CaseViews/", "./Classes/Views/SwiftUI/"]
+        sources: ["./Classes/Main/", "./Classes/Case/", "./Classes/Views/BaseViews/", "./Classes/Views/CaseViews/", "./Classes/Views/SwiftUI/"],
+        resources: [.copy("./SupportingFiles/PrivacyInfo.xcprivacy")]
     )
   ]
 )

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ someLabe.loc.titleKey = .somePolygotKey
 Attributed strings
 ```
 
+## Privacy
+
+SwiftI18n does not collect any user data. We have provided a [privacy manifest](https://github.com/infinum/ios-swiftI18n/blob/master/SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy) file that can be included in your app.
+
 ## Author
 
 Vlaho Poluta, vlaho.poluta@infinum.hr

--- a/SwiftI18n.podspec
+++ b/SwiftI18n.podspec
@@ -22,17 +22,18 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.0'
-  s.resource_bundles = { 'SwiftI18n' => ['SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy'] }
   
   s.default_subspec = 'I18n'
   s.subspec "I18n" do  |spec|
     source_files = ['SwiftI18n/Classes/Main/**/*', 'SwiftI18n/Classes/Views/{BaseViews,PlainViews,SwiftUI}/**/*']
     spec.source_files = source_files
+    spec.resource_bundles = { 'SwiftI18n' => ['SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy'] }
   end
 
   s.subspec "I18n+Case" do  |spec|
     source_files = ['SwiftI18n/Classes/{Main,Case}/**/*', 'SwiftI18n/Classes/Views/{BaseViews,CaseViews,SwiftUI}/**/*']
     spec.source_files = source_files
+    spec.resource_bundles = { 'SwiftI18n' => ['SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy'] }
   end
 
 end

--- a/SwiftI18n.podspec
+++ b/SwiftI18n.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftI18n'
-  s.version          = '1.3.0'
+  s.version          = '1.3.1'
   s.summary          = 'I18n library for Swift'
   s.homepage         = 'https://github.com/infinum/ios-swiftI18n'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.ios.deployment_target = '13.0'
   s.swift_version = '5.0'
+  s.resource_bundles = { 'SwiftI18n' => ['SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy'] }
   
   s.default_subspec = 'I18n'
   s.subspec "I18n" do  |spec|

--- a/SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy
+++ b/SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
 		<dict>

--- a/SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy
+++ b/SwiftI18n/SupportingFiles/PrivacyInfo.xcprivacy
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
### This PR adds privacy manifest to the library

A couple of notes to the reviewers:

- I have bumped the lib version to 1.3.1
- I have tried it out with Cocoapods and it works
- I updated Readme.md
- I raised minimum deployment version of the Example project to 13.0 since it failed to build otherwise
- I had to set `resource_bundles` under each subspec, otherwise `/Resources` folder would not be included if you target a subspec in your `Podfile`
- I have added CA92.1 as the Reason to use UserDefaults, but I am not certain because SwiftI18n writes to `"appleLanguages"` key in the userDefaults to override localization settings. That may mean that its usage of UserDefaults falls under some other category, but I am not sure. Maybe AC6B.1 could be a more appropriate option, but since it only mentions ` com.apple.configuration.managed` and `com.apple.feedback.managed` keys, I went with CA92.1 