### PR TITLE
Fix LocText translation handling

### DIFF
--- a/SwiftI18n.podspec
+++ b/SwiftI18n.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftI18n'
-  s.version          = '1.3.1'
+  s.version          = '1.3.2'
   s.summary          = 'I18n library for Swift'
   s.homepage         = 'https://github.com/infinum/ios-swiftI18n'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SwiftI18n/Classes/Views/SwiftUI/LocText.swift
+++ b/SwiftI18n/Classes/Views/SwiftUI/LocText.swift
@@ -7,48 +7,39 @@
 
 import SwiftUI
 
-enum SwiftI18nKey: EnvironmentKey {
-    static var defaultValue: String = I18nManager.instance.language
-}
-
-public extension EnvironmentValues {
-    
-    var language: String {
-        get { self[SwiftI18nKey.self] }
-        set { self[SwiftI18nKey.self] = newValue }
-    }
-}
-
 public struct LanguageModifier: ViewModifier {
-    
-    @State private var language = I18nManager.instance.language
-    
-    public init(){}
+
+    private let didUpdatedLanguage: (String) -> Void
+
+    public init(didUpdatedLanguage: @escaping (String) -> Void){
+        self.didUpdatedLanguage = didUpdatedLanguage
+    }
 
     public func body(content: Content) -> some View {
         content
             .onReceive(
                 NotificationCenter.default.publisher(for: .loc_LanguageDidChangeNotification).receive(on: DispatchQueue.main)
             ) { _ in
-                language = I18nManager.instance.language
+                didUpdatedLanguage(I18nManager.instance.language)
             }
-            .environment(\.language, language)
     }
-    
 }
 
 public struct LocText: View {
 
     fileprivate let content: [Content]
-    @Environment(\.language) private var language
+    @State private var language = I18nManager.instance.language
 
     public var text: Text {
         content
             .map { $0.text(localizedIn: language) }
             .reduce(Text(""), +)
     }
-    
-    public var body: some View { text }
+
+    public var body: some View {
+        text
+            .modifier(LanguageModifier(didUpdatedLanguage: { language = $0 }))
+    }
 }
 
 private extension LocText {
@@ -70,14 +61,14 @@ private extension LocText {
 
 
 public extension LocText {
-    
+
     init(_ key: String) {
         self.content = [.key(key)]
     }
 }
 
 public extension LocText {
-    
+
     static func + (lhs: LocText, rhs: LocText) -> LocText {
         LocText(content: lhs.content + rhs.content)
     }


### PR DESCRIPTION
## Intro
This PR is a quick hotfix for handling `LocText` translation in case where we have to modify the underlying `Text` by calling the `public var text: Text` property. 
In the future, we can see if we can remove that property from the lib, but in that case, we will have to introduce support for setting some properties on underlying `Text`.

## Issue

In case we use `public var text: Text` from the `LocText` directly (use-case example later), we will get the error:
![Screenshot 2024-06-12 at 16 19 19](https://github.com/infinum/ios-swiftI18n/assets/11990539/3649bd61-02c9-4bcc-a4c6-f5f19ec722d6)

This will result in a **not translated** `LocText` element (only the default language will be set; a language change will not take effect).

## Fix
To fix this behavior, I replaced `@Environment(\.language)` base handling with *completion* base one. I can even remove `LanguageModifier` if we don't need it (not sure if someone is using it?), and we can call `.onReceive` directly on `LocText` `text` inside the `body`. 
That way, when a language change occurs and a notification is fired, `@State` will be updated, and we will have a correct translation on the next `body` render.

## Use Case

In case when we want to set `kerning` and `lineSpacing` on font, we have to access `Text` directly as those modifiers are not available on `Content` (e.g., creating the `ViewModifier`) or `View` (i.e., on `LocText`). In that case, we can use the existing `public var text: Text` property on which we can then apply `kerning ` and `lineSpacing`. Example:
```swift
extension LocText {

    func appFont(_ fontStyle: AppFontStyle) -> some View {
        return text // returns `Text`
            .font(fontStyle.font)
            .kerning(fontStyle.style.kern) // available only on `Text`
            .lineSpacing(fontStyle.lineSpacing)
            .padding(.vertical, fontStyle.lineSpacing / 2)
    }
}
```