### PR TITLE
Add a11y localization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,23 @@ or if you prefer notifications, you can use:
 
 ```swift
 someLabel.locTitleKey = "some_key"
+someButton.locAccessibilityLabelKey = "button_accessibility_label_key"
+someButton.locAccessibilityHintKey = "button_accessibility_hint_key"
 ```
 
-Now when language changes, your `someLabel`'s title automaticaly changes. Isn't that great!?
+Now when language changes, your `someLabel`'s title, accessibility label and hint, automaticaly change. Isn't that great!?
 
 Supported elements:
-```UILabel ```
-```UIButton ```
-```UITextFiled ```
-```UITextView ```
-```UIViewController ```
-```UIBarButtonItem ```
-```UITabBarItem ```
-```UINavigationItem ```
+```UILabel```
+```UIButton```
+```UITextFiled```
+```UITextView```
+```UIViewController```
+```UIBarButtonItem```
+```UITabBarItem```
+```UINavigationItem```
 
-**And the most important thing, all of those `locTitleKey`'s are supported in ```Storyboards ``` as ```@IBInspectable ```.**
+**And the most important thing, all of those `locTitleKey`s, `locAccessibilityLabelKey`s, `locAccessibilityHintKey`s are supported in ```Storyboards ``` as ```@IBInspectable ```.**
 
 ### SwiftUI Support
 
@@ -144,7 +146,9 @@ into your project.
 By doing this you can now set translations to your UI elements with ease:
 
 ```swift
-someLabe.loc.titleKey = .somePolygotKey
+someLabel.loc.titleKey = .somePolygotKey
+someButton.loc.accessibilityLabelKey = .somePolyglotKey
+someButton.loc.accessibilityLabelHint = .somePolyglotKey
 ```
 
 ## Not supported 

--- a/SwiftI18n/Classes/Main/Localizable.swift
+++ b/SwiftI18n/Classes/Main/Localizable.swift
@@ -14,6 +14,8 @@ public struct Localizable<Base: LocKeyAcceptable> {
 
 public protocol LocKeyAcceptable: AnyObject {
     var locTitleKey: String? { get set }
+    var locAccessibilityLabelKey: String? { get set }
+    var locAccessibilityHintKey: String? { get set }
 }
 
 public extension LocKeyAcceptable {

--- a/SwiftI18n/Classes/Views/BaseViews/UIBarButtonItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIBarButtonItem+I18n_loc.swift
@@ -15,9 +15,8 @@ public extension UIBarButtonItem {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UIBarButtonItem.loc_titleKey]
+            loc_keysDictionary[UIBarButtonItem.loc_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UIBarButtonItem.loc_titleKey] = newValue
             loc_localeDidChange()
@@ -26,9 +25,8 @@ public extension UIBarButtonItem {
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]
+            loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -37,13 +35,11 @@ public extension UIBarButtonItem {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]
+            loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }
-
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UIBarButtonItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIBarButtonItem+I18n_loc.swift
@@ -10,16 +10,40 @@ import UIKit
 public extension UIBarButtonItem {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UIViewController.loc_titleKey]
+            return loc_keysDictionary[UIBarButtonItem.loc_titleKey]
         }
         
         set(newValue) {
-            loc_keysDictionary[UIViewController.loc_titleKey] = newValue
+            loc_keysDictionary[UIBarButtonItem.loc_titleKey] = newValue
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
@@ -23,9 +23,8 @@ public extension UIButton {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return locTitleKey(for: .normal)
+            locTitleKey(for: .normal)
         }
-        
         set(newValue) {
             loc_allStates.forEach { setLocTitleKey(newValue, for: $0) }
             loc_localeDidChange()
@@ -37,14 +36,13 @@ public extension UIButton {
     }
     
     func locTitleKey(`for` state: UIControl.State) -> String? {
-        return loc_keysDictionary[state]
+        loc_keysDictionary[state]
     }
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UIButton.loc_accessibilityLabelKey]
+            loc_keysDictionary[UIButton.loc_accessibilityLabelKey]
         }
-
         set {
             loc_keysDictionary[UIButton.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -53,9 +51,8 @@ public extension UIButton {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UIButton.loc_accessibilityHintKey]
+            loc_keysDictionary[UIButton.loc_accessibilityHintKey]
         }
-        
         set {
             loc_keysDictionary[UIButton.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
@@ -65,5 +62,4 @@ public extension UIButton {
     var loc_allStates: [UIControl.State] {
         return [.normal, .disabled, .highlighted, .selected]
     }
-    
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
@@ -17,7 +17,10 @@ extension UIControl.State: Hashable {
 }
 
 public extension UIButton {
-    
+
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return locTitleKey(for: .normal)
@@ -36,10 +39,31 @@ public extension UIButton {
     func locTitleKey(`for` state: UIControl.State) -> String? {
         return loc_keysDictionary[state]
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UIButton.loc_accessibilityLabelKey]
+        }
+
+        set {
+            loc_keysDictionary[UIButton.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UIButton.loc_accessibilityHintKey]
+        }
+        
+        set {
+            loc_keysDictionary[UIButton.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
     var loc_allStates: [UIControl.State] {
         return [.normal, .disabled, .highlighted, .selected]
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
@@ -16,9 +16,8 @@ public extension UILabel {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UILabel.loc_titleKey]
+            loc_keysDictionary[UILabel.loc_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UILabel.loc_titleKey] = newValue
             loc_localeDidChange()
@@ -27,9 +26,8 @@ public extension UILabel {
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UILabel.loc_accessibilityLabelKey]
+            loc_keysDictionary[UILabel.loc_accessibilityLabelKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UILabel.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -38,13 +36,11 @@ public extension UILabel {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UILabel.loc_accessibilityHintKey]
+            loc_keysDictionary[UILabel.loc_accessibilityHintKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UILabel.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }
-    
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
@@ -11,7 +11,9 @@ import UIKit
 public extension UILabel {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UILabel.loc_titleKey]
@@ -19,6 +21,28 @@ public extension UILabel {
         
         set(newValue) {
             loc_keysDictionary[UILabel.loc_titleKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UILabel.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UILabel.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UILabel.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UILabel.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
@@ -15,11 +15,11 @@ public extension UINavigationItem {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UIViewController.loc_titleKey]
+            return loc_keysDictionary[UINavigationItem.loc_titleKey]
         }
 
         set(newValue) {
-            loc_keysDictionary[UIViewController.loc_titleKey] = newValue
+            loc_keysDictionary[UINavigationItem.loc_titleKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
@@ -10,7 +10,9 @@ import UIKit
 public extension UINavigationItem {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UIViewController.loc_titleKey]
@@ -21,6 +23,27 @@ public extension UINavigationItem {
             loc_localeDidChange()
         }
     }
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]
+        }
+
+        set {
+            loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]
+        }
+        
+        set {
+            loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
     
 }
-

--- a/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
@@ -15,9 +15,8 @@ public extension UINavigationItem {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UINavigationItem.loc_titleKey]
+            loc_keysDictionary[UINavigationItem.loc_titleKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UINavigationItem.loc_titleKey] = newValue
             loc_localeDidChange()
@@ -26,9 +25,8 @@ public extension UINavigationItem {
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]
+            loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]
         }
-
         set {
             loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -37,13 +35,11 @@ public extension UINavigationItem {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]
+            loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]
         }
-        
         set {
             loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }
-    
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
@@ -16,9 +16,8 @@ public extension UISearchBar {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UISearchBar.loc_titleKey]
+            loc_keysDictionary[UISearchBar.loc_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UISearchBar.loc_titleKey] = newValue
             loc_localeDidChange()
@@ -27,19 +26,18 @@ public extension UISearchBar {
     
     @IBInspectable var locPlaceholderKey: String? {
         get {
-            return loc_keysDictionary[UISearchBar.loc_placeholderKey]
+            loc_keysDictionary[UISearchBar.loc_placeholderKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UISearchBar.loc_placeholderKey] = newValue
             loc_localeDidChange()
         }
     }
+
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]
+            loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -48,12 +46,11 @@ public extension UISearchBar {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]
+            loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]
         }
         set(newValue) {
             loc_keysDictionary[UISearchBar.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }
-
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
@@ -11,7 +11,9 @@ public extension UISearchBar {
     
     static let loc_titleKey = "KEY"
     static let loc_placeholderKey = "PKEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UISearchBar.loc_titleKey]
@@ -27,10 +29,31 @@ public extension UISearchBar {
         get {
             return loc_keysDictionary[UISearchBar.loc_placeholderKey]
         }
+
         set(newValue) {
             loc_keysDictionary[UISearchBar.loc_placeholderKey] = newValue
             loc_localeDidChange()
         }
     }
-    
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]
+        }
+        set(newValue) {
+            loc_keysDictionary[UISearchBar.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
@@ -15,9 +15,8 @@ public extension UITabBarItem {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UITabBarItem.loc_titleKey]
+            loc_keysDictionary[UITabBarItem.loc_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITabBarItem.loc_titleKey] = newValue
             loc_localeDidChange()
@@ -26,9 +25,8 @@ public extension UITabBarItem {
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]
+            loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -37,14 +35,12 @@ public extension UITabBarItem {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]
+            loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }
-
 }
 

--- a/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
@@ -15,11 +15,11 @@ public extension UITabBarItem {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UIViewController.loc_titleKey]
+            return loc_keysDictionary[UITabBarItem.loc_titleKey]
         }
         
         set(newValue) {
-            loc_keysDictionary[UIViewController.loc_titleKey] = newValue
+            loc_keysDictionary[UITabBarItem.loc_titleKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
@@ -10,7 +10,9 @@ import UIKit
 public extension UITabBarItem {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UIViewController.loc_titleKey]
@@ -21,6 +23,28 @@ public extension UITabBarItem {
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]
+        }
+        
+        set(newValue) {
+            loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }
 

--- a/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
@@ -17,9 +17,8 @@ public extension UITextField {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UITextField.loc_titleKey]
+            loc_keysDictionary[UITextField.loc_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextField.loc_titleKey] = newValue
             loc_localeDidChange()
@@ -28,9 +27,8 @@ public extension UITextField {
     
     @IBInspectable var locPlaceholderKey: String? {
         get {
-            return loc_keysDictionary[UITextField.loc_placeholderKey]
+            loc_keysDictionary[UITextField.loc_placeholderKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextField.loc_placeholderKey] = newValue
             loc_localeDidChange()
@@ -39,9 +37,8 @@ public extension UITextField {
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UITextField.loc_accessibilityLabelKey]
+            loc_keysDictionary[UITextField.loc_accessibilityLabelKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UITextField.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -50,13 +47,11 @@ public extension UITextField {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UITextField.loc_accessibilityHintKey]
+            loc_keysDictionary[UITextField.loc_accessibilityHintKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextField.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }
-
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
@@ -12,7 +12,9 @@ public extension UITextField {
     
     static let loc_titleKey = "KEY"
     static let loc_placeholderKey = "PKEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UITextField.loc_titleKey]
@@ -34,5 +36,27 @@ public extension UITextField {
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UITextField.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UITextField.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UITextField.loc_accessibilityHintKey]
+        }
+        
+        set(newValue) {
+            loc_keysDictionary[UITextField.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
@@ -16,21 +16,18 @@ public extension UITextView {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UITextView.loc_titleKey]
+            loc_keysDictionary[UITextView.loc_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextView.loc_titleKey] = newValue
             loc_localeDidChange()
         }
-        
     }
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UITextView.loc_accessibilityLabelKey]
+            loc_keysDictionary[UITextView.loc_accessibilityLabelKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextView.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -39,15 +36,12 @@ public extension UITextView {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UITextView.loc_accessibilityHintKey]
+            loc_keysDictionary[UITextView.loc_accessibilityHintKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UITextView.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
-
     }
-
 }
 

--- a/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
@@ -8,12 +8,13 @@
 
 import UIKit
 
-extension UITextView {
-    
+public extension UITextView {
+
     static let loc_titleKey = "KEY"
-    
-    @IBInspectable public var locTitleKey: String? {
-        
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
+    @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UITextView.loc_titleKey]
         }
@@ -24,6 +25,29 @@ extension UITextView {
         }
         
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UITextView.loc_accessibilityLabelKey]
+        }
+        
+        set(newValue) {
+            loc_keysDictionary[UITextView.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UITextView.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UITextView.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+
+    }
+
 }
 

--- a/SwiftI18n/Classes/Views/BaseViews/ViewController+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/ViewController+I18n_loc.swift
@@ -16,9 +16,8 @@ public extension UIViewController {
 
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UIViewController.loc_titleKey]
+            loc_keysDictionary[UIViewController.loc_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UIViewController.loc_titleKey] = newValue
             loc_localeDidChange()
@@ -27,9 +26,8 @@ public extension UIViewController {
 
     @IBInspectable var locAccessibilityLabelKey: String? {
         get {
-            return loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]
+            loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UIViewController.loc_accessibilityLabelKey] = newValue
             loc_localeDidChange()
@@ -38,13 +36,11 @@ public extension UIViewController {
 
     @IBInspectable var locAccessibilityHintKey: String? {
         get {
-            return loc_keysDictionary[UIViewController.loc_accessibilityHintKey]
+            loc_keysDictionary[UIViewController.loc_accessibilityHintKey]
         }
-
         set(newValue) {
             loc_keysDictionary[UIViewController.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }
-
 }

--- a/SwiftI18n/Classes/Views/BaseViews/ViewController+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/ViewController+I18n_loc.swift
@@ -11,7 +11,9 @@ import UIKit
 public extension UIViewController {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UIViewController.loc_titleKey]
@@ -22,5 +24,27 @@ public extension UIViewController {
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIViewController.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UIViewController.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIViewController.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UIBarButtonItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIBarButtonItem+I18n_case.swift
@@ -12,11 +12,9 @@ extension UIBarButtonItem: I18n {
     private static let case_titleKey = "CKEY"
     
     @IBInspectable public var caseTransform: String? {
-        
         get {
-            return loc_keysDictionary[UIBarButtonItem.case_titleKey]
+            loc_keysDictionary[UIBarButtonItem.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UIBarButtonItem.case_titleKey] = newValue
             loc_localeDidChange()
@@ -24,11 +22,9 @@ extension UIBarButtonItem: I18n {
     }
     
     func loc_localeDidChange() {
-        self.title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised
+        title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UIBarButtonItem.case_titleKey] ?? ""))
-        
-        self.accessibilityLabel = loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]?.localised
     }
-
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UIBarButtonItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIBarButtonItem+I18n_case.swift
@@ -24,13 +24,11 @@ extension UIBarButtonItem: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
+        self.title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UIBarButtonItem.case_titleKey] ?? ""))
         
-        let caseTransform = loc_keysDictionary[UIBarButtonItem.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.accessibilityLabel = loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]?.localised
     }
-    
+
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
@@ -13,11 +13,9 @@ extension UIButton: I18n {
     private static let case_titleKey = "CKEY"
     
     @IBInspectable public var caseTransform: String? {
-        
         get {
-            return caseTransform(for: .normal)?.rawValue
+            caseTransform(for: .normal)?.rawValue
         }
-        
         set(newValue) {
             loc_allStates.forEach { setCaseTransform(I18nCaseTransform(rawValue: newValue ?? ""), for: $0) }
             loc_localeDidChange()
@@ -34,8 +32,8 @@ extension UIButton: I18n {
     
     func loc_localeDidChange() {
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
-        self.accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
     }
     
     func loc_localeDidChange(`for` state: UIControl.State) {
@@ -47,5 +45,4 @@ extension UIButton: I18n {
         let caseTransform = loc_keysDictionary["\(state)\(UIButton.case_titleKey)"]
         setTitle(text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? "")), for: state)
     }
-    
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
@@ -34,6 +34,8 @@ extension UIButton: I18n {
     
     func loc_localeDidChange() {
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
+        self.accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
     }
     
     func loc_localeDidChange(`for` state: UIControl.State) {
@@ -47,4 +49,3 @@ extension UIButton: I18n {
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
@@ -25,13 +25,11 @@ extension UILabel: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let text = loc_keysDictionary[UILabel.loc_titleKey]?.localised else {
-            self.text = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UILabel.case_titleKey]
-        self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UILabel.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised
     }
-    
+
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
@@ -13,11 +13,9 @@ extension UILabel: I18n {
     private static let case_titleKey = "CKEY"
     
     @IBInspectable public var caseTransform: String? {
-        
         get {
-            return loc_keysDictionary[UILabel.case_titleKey]
+            loc_keysDictionary[UILabel.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UILabel.case_titleKey] = newValue
             loc_localeDidChange()
@@ -25,11 +23,9 @@ extension UILabel: I18n {
     }
     
     func loc_localeDidChange() {
-        self.text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
+        text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UILabel.case_titleKey] ?? ""))
-
-        self.accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised
     }
-
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UINavigationItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UINavigationItem+I18n_case.swift
@@ -24,13 +24,11 @@ extension UINavigationItem: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UINavigationItem.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UINavigationItem.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UINavigationItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UINavigationItem+I18n_case.swift
@@ -12,11 +12,9 @@ extension UINavigationItem: I18n {
     private static let case_titleKey = "CKEY"
     
     @IBInspectable public var caseTransform: String? {
-        
         get {
-            return loc_keysDictionary[UINavigationItem.case_titleKey]
+            loc_keysDictionary[UINavigationItem.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UINavigationItem.case_titleKey] = newValue
             loc_localeDidChange()
@@ -24,11 +22,9 @@ extension UINavigationItem: I18n {
     }
     
     func loc_localeDidChange() {
-        self.title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised
+        title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UINavigationItem.case_titleKey] ?? ""))
-
-        self.accessibilityLabel = loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]?.localised
     }
-    
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
@@ -39,22 +39,14 @@ extension UISearchBar: I18n {
     }
     
     func loc_localeDidChange() {
-        let text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
-        let placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
-        
-        if let text = text {
-            let caseTransform = loc_keysDictionary[UISearchBar.case_titleKey]
-            self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
-        } else {
-            self.text = nil
-        }
-        
-        if let placeholder = placeholder {
-            let casePlaceholderTransform = loc_keysDictionary[UISearchBar.case_placeholderKey]
-            self.placeholder = placeholder.transform(with: I18nCaseTransform(rawValue: casePlaceholderTransform ?? ""))
-        } else {
-            self.placeholder = nil
-        }
+        self.text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_titleKey] ?? ""))
+
+        self.placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_placeholderKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
@@ -13,40 +13,31 @@ extension UISearchBar: I18n {
     private static let case_placeholderKey = "CPKEY"
     
     @IBInspectable public var caseTransform: String? {
-        
         get {
-            return loc_keysDictionary[UISearchBar.case_titleKey]
+            loc_keysDictionary[UISearchBar.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UISearchBar.case_titleKey] = newValue
             loc_localeDidChange()
         }
-        
     }
     
     @IBInspectable public var casePlaceholderTransform: String? {
-        
         get {
-            return loc_keysDictionary[UISearchBar.case_placeholderKey]
+            loc_keysDictionary[UISearchBar.case_placeholderKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UISearchBar.case_placeholderKey] = newValue
             loc_localeDidChange()
         }
-        
     }
     
     func loc_localeDidChange() {
-        self.text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
+        text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_titleKey] ?? ""))
-
-        self.placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
+        placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_placeholderKey] ?? ""))
-
-        self.accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]?.localised
     }
-    
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITabBarItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITabBarItem+I18n_case.swift
@@ -24,14 +24,11 @@ extension UITabBarItem: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UITabBarItem.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITabBarItem.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]?.localised
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/CaseViews/UITabBarItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITabBarItem+I18n_case.swift
@@ -12,11 +12,9 @@ extension UITabBarItem: I18n {
     private static let case_titleKey = "CKEY"
     
     @IBInspectable public var caseTransform: String? {
-        
         get {
-            return loc_keysDictionary[UITabBarItem.case_titleKey]
+            loc_keysDictionary[UITabBarItem.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITabBarItem.case_titleKey] = newValue
             loc_localeDidChange()
@@ -24,11 +22,9 @@ extension UITabBarItem: I18n {
     }
     
     func loc_localeDidChange() {
-        self.title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised
+        title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITabBarItem.case_titleKey] ?? ""))
-
-        self.accessibilityLabel = loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]?.localised
     }
-    
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
@@ -14,11 +14,9 @@ extension UITextField: I18n {
     private static let case_placeholderKey = "CPKEY"
     
     @IBInspectable public var caseTransform: String? {
-    
         get {
-            return loc_keysDictionary[UITextField.case_titleKey]
+            loc_keysDictionary[UITextField.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextField.case_titleKey] = newValue
             loc_localeDidChange()
@@ -26,11 +24,9 @@ extension UITextField: I18n {
     }
     
     @IBInspectable public var casePlaceholderTransform: String? {
-    
         get {
-            return loc_keysDictionary[UITextField.case_placeholderKey]
+            loc_keysDictionary[UITextField.case_placeholderKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextField.case_placeholderKey] = newValue
             loc_localeDidChange()
@@ -38,14 +34,11 @@ extension UITextField: I18n {
     }
     
     func loc_localeDidChange() {
-        self.text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
+        text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_titleKey] ?? ""))
-
-        self.placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
+        placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_placeholderKey] ?? ""))
-
-        self.accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UITextField.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UITextField.loc_accessibilityHintKey]?.localised
     }
-    
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
@@ -38,23 +38,14 @@ extension UITextField: I18n {
     }
     
     func loc_localeDidChange() {
-        let text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
-        let placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
-        
-        if let text = text {
-            let caseTransform = loc_keysDictionary[UITextField.case_titleKey]
-            self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
-        } else {
-            self.text = nil
-        }
-        
-        if let placeholder = placeholder {
-            let casePlaceholderTransform = loc_keysDictionary[UITextField.case_placeholderKey]
-            self.placeholder = placeholder.transform(with: I18nCaseTransform(rawValue: casePlaceholderTransform ?? ""))
-        } else {
-            self.placeholder = nil
-        }
-        
+        self.text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_titleKey] ?? ""))
+
+        self.placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_placeholderKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UITextField.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
@@ -13,11 +13,9 @@ extension UITextView: I18n {
     private static let case_titleKey = "CKEY"
     
     @IBInspectable public var caseTransform: String? {
-    
         get {
-            return loc_keysDictionary[UITextView.case_titleKey]
+            loc_keysDictionary[UITextView.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UITextView.case_titleKey] = newValue
             loc_localeDidChange()
@@ -25,11 +23,10 @@ extension UITextView: I18n {
     }
     
     func loc_localeDidChange() {
-        self.text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
+        text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextView.case_titleKey] ?? "")) ?? ""
 
-        self.accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised
     }
-    
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
@@ -25,14 +25,11 @@ extension UITextView: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let text = loc_keysDictionary[UITextView.loc_titleKey]?.localised else {
-            self.text  = ""
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UITextView.case_titleKey]
-        self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextView.case_titleKey] ?? "")) ?? ""
+
+        self.accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/CaseViews/ViewController+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/ViewController+I18n_case.swift
@@ -25,13 +25,11 @@ extension UIViewController: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UIViewController.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UIViewController.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UIViewController.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/CaseViews/ViewController+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/ViewController+I18n_case.swift
@@ -13,11 +13,9 @@ extension UIViewController: I18n {
     private static let case_titleKey = "CKEY"
     
     @IBInspectable public var caseTransform: String? {
-    
         get {
-            return loc_keysDictionary[UIViewController.case_titleKey]
+            loc_keysDictionary[UIViewController.case_titleKey]
         }
-        
         set(newValue) {
             loc_keysDictionary[UIViewController.case_titleKey] = newValue
             loc_localeDidChange()
@@ -25,11 +23,10 @@ extension UIViewController: I18n {
     }
     
     func loc_localeDidChange() {
-        self.title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised
+        title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UIViewController.case_titleKey] ?? ""))
 
-        self.accessibilityLabel = loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]?.localised
-        self.accessibilityHint = loc_keysDictionary[UIViewController.loc_accessibilityHintKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UIViewController.loc_accessibilityHintKey]?.localised
     }
-    
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UIBarButtonItem+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UIBarButtonItem+I18n.swift
@@ -10,7 +10,7 @@ import UIKit
 extension UIBarButtonItem: I18n {
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UILabel.loc_titleKey]?.localised else {return}
+        guard let title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised else {return}
         self.title = title
     }
     

--- a/SwiftI18n/Classes/Views/PlainViews/UIBarButtonItem+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UIBarButtonItem+I18n.swift
@@ -10,8 +10,8 @@ import UIKit
 extension UIBarButtonItem: I18n {
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised else {return}
-        self.title = title
+        title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]?.localised
     }
-    
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
@@ -12,10 +12,12 @@ extension UIButton: I18n {
     
     func loc_localeDidChange() {
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
+        accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
     }
     
     func loc_localeDidChange(`for` state: UIControl.State) {
-        guard let text = loc_keysDictionary[state]?.localised  else {return}
+        guard let text = loc_keysDictionary[state]?.localised  else { return }
         setTitle(text, for: state)
     }
     

--- a/SwiftI18n/Classes/Views/PlainViews/UILabel+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UILabel+I18n.swift
@@ -11,8 +11,9 @@ import UIKit
 extension UILabel: I18n {
     
     func loc_localeDidChange() {
-        guard let text = loc_keysDictionary[UILabel.loc_titleKey]?.localised else {return}
-        self.text = text
+        text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UINavigationItem+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UINavigationItem+I18n.swift
@@ -10,8 +10,9 @@ import UIKit
 extension UINavigationItem: I18n {
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised else {return}
-        self.title = title
+        title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UINavigationItem+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UINavigationItem+I18n.swift
@@ -10,7 +10,7 @@ import UIKit
 extension UINavigationItem: I18n {
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UILabel.loc_titleKey]?.localised else {return}
+        guard let title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised else {return}
         self.title = title
     }
     

--- a/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
@@ -10,9 +10,9 @@ import UIKit
 extension UISearchBar: I18n {
 
     func loc_localeDidChange() {
-        let text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
-        let placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
-        
+        let text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
+        let placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
+
         if let text = text {
             self.text = text
         }

--- a/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
@@ -10,16 +10,10 @@ import UIKit
 extension UISearchBar: I18n {
 
     func loc_localeDidChange() {
-        let text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
-        let placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
-
-        if let text = text {
-            self.text = text
-        }
-        
-        if let placeholder = placeholder {
-            self.placeholder = placeholder
-        }
+        text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
+        placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]?.localised
     }
 
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UITabBarItem+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITabBarItem+I18n.swift
@@ -10,8 +10,9 @@ import UIKit
 extension UITabBarItem: I18n {
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised else {return}
-        self.title = title
+        title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UITabBarItem+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITabBarItem+I18n.swift
@@ -10,7 +10,7 @@ import UIKit
 extension UITabBarItem: I18n {
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UILabel.loc_titleKey]?.localised else {return}
+        guard let title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised else {return}
         self.title = title
     }
     

--- a/SwiftI18n/Classes/Views/PlainViews/UITextField+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITextField+I18n.swift
@@ -11,17 +11,10 @@ import UIKit
 extension UITextField: I18n {
     
     func loc_localeDidChange() {
-        let text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
-        let placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
-        
-        if let text = text {
-            self.text = text
-        }
-        
-        if let placeholder = placeholder {
-            self.placeholder = placeholder
-        }
-        
+        text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
+        placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UITextField.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UITextView+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITextView+I18n.swift
@@ -11,8 +11,9 @@ import UIKit
 extension UITextView: I18n {
     
     func loc_localeDidChange() {
-        guard let text = loc_keysDictionary[UITextView.loc_titleKey]?.localised else {return}
-        self.text = text
+        text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/ViewController+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/ViewController+I18n.swift
@@ -11,8 +11,9 @@ import UIKit
 extension UIViewController: I18n {
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised else {return}
-        self.title = title
+        title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised
+        accessibilityLabel = loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[UIViewController.loc_accessibilityHintKey]?.localised
     }
     
 }


### PR DESCRIPTION
## Description
This PR adds localization support for accessibility labels and hints.
Added `loc_accessibilityLabel` and `loc_accessibilityHint` to enable accessibility localization updates.
Also simplified the code in `loc_localeDidChange()` functions a bit.

## Use case
Assigning keys for accessibility labels and hints is as straightforward as for labels:
```
someLabel.locAccessibilityLabelKey = "some_key"
someLabel.locAccessibilityHintKey = "some_key"
```