### PR TITLE
Change accessibility language on app language change

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,23 @@ or if you prefer notifications, you can use:
 
 ```swift
 someLabel.locTitleKey = "some_key"
+someButton.locAccessibilityLabelKey = "button_accessibility_label_key"
+someButton.locAccessibilityHintKey = "button_accessibility_hint_key"
 ```
 
-Now when language changes, your `someLabel`'s title automaticaly changes. Isn't that great!?
+Now when language changes, your `someLabel`'s title, accessibility label and hint, automaticaly change. Isn't that great!?
 
 Supported elements:
-```UILabel ```
-```UIButton ```
-```UITextFiled ```
-```UITextView ```
-```UIViewController ```
-```UIBarButtonItem ```
-```UITabBarItem ```
-```UINavigationItem ```
+```UILabel```
+```UIButton```
+```UITextFiled```
+```UITextView```
+```UIViewController```
+```UIBarButtonItem```
+```UITabBarItem```
+```UINavigationItem```
 
-**And the most important thing, all of those `locTitleKey`'s are supported in ```Storyboards ``` as ```@IBInspectable ```.**
+**And the most important thing, all of those `locTitleKey`s, `locAccessibilityLabelKey`s, `locAccessibilityHintKey`s are supported in ```Storyboards ``` as ```@IBInspectable ```.**
 
 ### SwiftUI Support
 
@@ -144,7 +146,9 @@ into your project.
 By doing this you can now set translations to your UI elements with ease:
 
 ```swift
-someLabe.loc.titleKey = .somePolygotKey
+someLabel.loc.titleKey = .somePolygotKey
+someButton.loc.accessibilityLabelKey = .somePolyglotKey
+someButton.loc.accessibilityLabelHint = .somePolyglotKey
 ```
 
 ## Not supported 

--- a/SwiftI18n.podspec
+++ b/SwiftI18n.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftI18n'
-  s.version          = '1.4.0'
+  s.version          = '1.5.0'
   s.summary          = 'I18n library for Swift'
   s.homepage         = 'https://github.com/infinum/ios-swiftI18n'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SwiftI18n/Classes/Main/I18nManager.swift
+++ b/SwiftI18n/Classes/Main/I18nManager.swift
@@ -51,10 +51,19 @@ public class I18nManager {
             NotificationCenter.default.post(name: .loc_LanguageDidChangeNotification, object: nil)
         }
         get {
-            guard UIApplication.shared.accessibilityLanguage == nil else { return getCurrentLanguage() }
-            let language = getCurrentLanguage()
-            UIApplication.shared.accessibilityLanguage = language
-            return language
+            if let language = _language {
+                return language
+            }
+            _language = UserDefaults.standard.string(forKey: .language)
+            if let language = _language {
+                return language
+            }
+            if let defaultLanguage = defaultLanguage {
+                return defaultLanguage
+            }
+            return availableLanguages
+                .flatMap { return Bundle.preferredLocalizations(from: $0, forPreferences: Locale.preferredLanguages).first }
+                ?? "en"
         }
     }
 }
@@ -94,25 +103,6 @@ public extension I18nManager {
     
     subscript(locKey: String) -> String {
         return localizedString(forKey: locKey)
-    }
-}
-
-private extension I18nManager {
-
-    func getCurrentLanguage() -> String {
-        if let language = _language {
-            return language
-        }
-        _language = UserDefaults.standard.string(forKey: .language)
-        if let language = _language {
-            return language
-        }
-        if let defaultLanguage = defaultLanguage {
-            return defaultLanguage
-        }
-        return availableLanguages
-            .flatMap { return Bundle.preferredLocalizations(from: $0, forPreferences: Locale.preferredLanguages).first }
-            ?? "en"
     }
 }
 

--- a/SwiftI18n/Classes/Main/I18nManager.swift
+++ b/SwiftI18n/Classes/Main/I18nManager.swift
@@ -47,6 +47,7 @@ public class I18nManager {
             _language = newValue
             UserDefaults.standard.set(newValue, forKey: .language)
             UserDefaults.standard.set([newValue], forKey: .appleLanguages)
+            UIApplication.shared.accessibilityLanguage = newValue
             NotificationCenter.default.post(name: .loc_LanguageDidChangeNotification, object: nil)
         }
         get {

--- a/SwiftI18n/Classes/Main/I18nManager.swift
+++ b/SwiftI18n/Classes/Main/I18nManager.swift
@@ -51,19 +51,10 @@ public class I18nManager {
             NotificationCenter.default.post(name: .loc_LanguageDidChangeNotification, object: nil)
         }
         get {
-            if let language = _language {
-                return language
-            }
-            _language = UserDefaults.standard.string(forKey: .language)
-            if let language = _language {
-                return language
-            }
-            if let defaultLanguage = defaultLanguage {
-                return defaultLanguage
-            }
-            return availableLanguages
-                .flatMap { return Bundle.preferredLocalizations(from: $0, forPreferences: Locale.preferredLanguages).first }
-                ?? "en"
+            guard UIApplication.shared.accessibilityLanguage == nil else { return getCurrentLanguage() }
+            let language = getCurrentLanguage()
+            UIApplication.shared.accessibilityLanguage = language
+            return language
         }
     }
 }
@@ -103,6 +94,25 @@ public extension I18nManager {
     
     subscript(locKey: String) -> String {
         return localizedString(forKey: locKey)
+    }
+}
+
+private extension I18nManager {
+
+    func getCurrentLanguage() -> String {
+        if let language = _language {
+            return language
+        }
+        _language = UserDefaults.standard.string(forKey: .language)
+        if let language = _language {
+            return language
+        }
+        if let defaultLanguage = defaultLanguage {
+            return defaultLanguage
+        }
+        return availableLanguages
+            .flatMap { return Bundle.preferredLocalizations(from: $0, forPreferences: Locale.preferredLanguages).first }
+            ?? "en"
     }
 }
 

--- a/SwiftI18n/Classes/Main/Localizable.swift
+++ b/SwiftI18n/Classes/Main/Localizable.swift
@@ -14,6 +14,8 @@ public struct Localizable<Base: LocKeyAcceptable> {
 
 public protocol LocKeyAcceptable: AnyObject {
     var locTitleKey: String? { get set }
+    var locAccessibilityLabelKey: String? { get set }
+    var locAccessibilityHintKey: String? { get set }
 }
 
 public extension LocKeyAcceptable {

--- a/SwiftI18n/Classes/Views/BaseViews/UIBarButtonItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIBarButtonItem+I18n_loc.swift
@@ -10,16 +10,40 @@ import UIKit
 public extension UIBarButtonItem {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
-            return loc_keysDictionary[UIViewController.loc_titleKey]
+            return loc_keysDictionary[UIBarButtonItem.loc_titleKey]
         }
         
         set(newValue) {
-            loc_keysDictionary[UIViewController.loc_titleKey] = newValue
+            loc_keysDictionary[UIBarButtonItem.loc_titleKey] = newValue
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
@@ -17,7 +17,10 @@ extension UIControl.State: Hashable {
 }
 
 public extension UIButton {
-    
+
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return locTitleKey(for: .normal)
@@ -36,10 +39,31 @@ public extension UIButton {
     func locTitleKey(`for` state: UIControl.State) -> String? {
         return loc_keysDictionary[state]
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UIButton.loc_accessibilityLabelKey]
+        }
+
+        set {
+            loc_keysDictionary[UIButton.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UIButton.loc_accessibilityHintKey]
+        }
+        
+        set {
+            loc_keysDictionary[UIButton.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
     var loc_allStates: [UIControl.State] {
         return [.normal, .disabled, .highlighted, .selected]
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
@@ -11,7 +11,9 @@ import UIKit
 public extension UILabel {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UILabel.loc_titleKey]
@@ -19,6 +21,28 @@ public extension UILabel {
         
         set(newValue) {
             loc_keysDictionary[UILabel.loc_titleKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UILabel.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UILabel.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UILabel.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UILabel.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UINavigationItem+I18n_loc.swift
@@ -10,7 +10,9 @@ import UIKit
 public extension UINavigationItem {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UIViewController.loc_titleKey]
@@ -21,6 +23,27 @@ public extension UINavigationItem {
             loc_localeDidChange()
         }
     }
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]
+        }
+
+        set {
+            loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]
+        }
+        
+        set {
+            loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
     
 }
-

--- a/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
@@ -11,7 +11,9 @@ public extension UISearchBar {
     
     static let loc_titleKey = "KEY"
     static let loc_placeholderKey = "PKEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UISearchBar.loc_titleKey]
@@ -27,10 +29,31 @@ public extension UISearchBar {
         get {
             return loc_keysDictionary[UISearchBar.loc_placeholderKey]
         }
+
         set(newValue) {
             loc_keysDictionary[UISearchBar.loc_placeholderKey] = newValue
             loc_localeDidChange()
         }
     }
-    
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]
+        }
+        set(newValue) {
+            loc_keysDictionary[UISearchBar.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITabBarItem+I18n_loc.swift
@@ -10,7 +10,9 @@ import UIKit
 public extension UITabBarItem {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UIViewController.loc_titleKey]
@@ -21,6 +23,28 @@ public extension UITabBarItem {
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]
+        }
+        
+        set(newValue) {
+            loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }
 

--- a/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
@@ -12,7 +12,9 @@ public extension UITextField {
     
     static let loc_titleKey = "KEY"
     static let loc_placeholderKey = "PKEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UITextField.loc_titleKey]
@@ -34,5 +36,27 @@ public extension UITextField {
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UITextField.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UITextField.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UITextField.loc_accessibilityHintKey]
+        }
+        
+        set(newValue) {
+            loc_keysDictionary[UITextField.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
@@ -8,12 +8,13 @@
 
 import UIKit
 
-extension UITextView {
-    
+public extension UITextView {
+
     static let loc_titleKey = "KEY"
-    
-    @IBInspectable public var locTitleKey: String? {
-        
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
+    @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UITextView.loc_titleKey]
         }
@@ -24,6 +25,29 @@ extension UITextView {
         }
         
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UITextView.loc_accessibilityLabelKey]
+        }
+        
+        set(newValue) {
+            loc_keysDictionary[UITextView.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UITextView.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UITextView.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+
+    }
+
 }
 

--- a/SwiftI18n/Classes/Views/BaseViews/ViewController+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/ViewController+I18n_loc.swift
@@ -11,7 +11,9 @@ import UIKit
 public extension UIViewController {
     
     static let loc_titleKey = "KEY"
-    
+    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+
     @IBInspectable var locTitleKey: String? {
         get {
             return loc_keysDictionary[UIViewController.loc_titleKey]
@@ -22,5 +24,27 @@ public extension UIViewController {
             loc_localeDidChange()
         }
     }
-    
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            return loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIViewController.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            return loc_keysDictionary[UIViewController.loc_accessibilityHintKey]
+        }
+
+        set(newValue) {
+            loc_keysDictionary[UIViewController.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UIBarButtonItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIBarButtonItem+I18n_case.swift
@@ -24,13 +24,11 @@ extension UIBarButtonItem: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
+        self.title = loc_keysDictionary[UIBarButtonItem.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UIBarButtonItem.case_titleKey] ?? ""))
         
-        let caseTransform = loc_keysDictionary[UIBarButtonItem.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.accessibilityLabel = loc_keysDictionary[UIBarButtonItem.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UIBarButtonItem.loc_accessibilityHintKey]?.localised
     }
-    
+
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
@@ -34,6 +34,8 @@ extension UIButton: I18n {
     
     func loc_localeDidChange() {
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
+        self.accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
     }
     
     func loc_localeDidChange(`for` state: UIControl.State) {
@@ -47,4 +49,3 @@ extension UIButton: I18n {
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
@@ -25,13 +25,11 @@ extension UILabel: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let text = loc_keysDictionary[UILabel.loc_titleKey]?.localised else {
-            self.text = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UILabel.case_titleKey]
-        self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UILabel.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised
     }
-    
+
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UINavigationItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UINavigationItem+I18n_case.swift
@@ -24,13 +24,11 @@ extension UINavigationItem: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UINavigationItem.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.title = loc_keysDictionary[UINavigationItem.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UINavigationItem.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UINavigationItem.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UINavigationItem.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
@@ -39,22 +39,14 @@ extension UISearchBar: I18n {
     }
     
     func loc_localeDidChange() {
-        let text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
-        let placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
-        
-        if let text = text {
-            let caseTransform = loc_keysDictionary[UISearchBar.case_titleKey]
-            self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
-        } else {
-            self.text = nil
-        }
-        
-        if let placeholder = placeholder {
-            let casePlaceholderTransform = loc_keysDictionary[UISearchBar.case_placeholderKey]
-            self.placeholder = placeholder.transform(with: I18nCaseTransform(rawValue: casePlaceholderTransform ?? ""))
-        } else {
-            self.placeholder = nil
-        }
+        self.text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_titleKey] ?? ""))
+
+        self.placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_placeholderKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITabBarItem+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITabBarItem+I18n_case.swift
@@ -24,14 +24,11 @@ extension UITabBarItem: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UITabBarItem.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.title = loc_keysDictionary[UITabBarItem.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITabBarItem.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UITabBarItem.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UITabBarItem.loc_accessibilityHintKey]?.localised
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
@@ -38,23 +38,14 @@ extension UITextField: I18n {
     }
     
     func loc_localeDidChange() {
-        let text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
-        let placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
-        
-        if let text = text {
-            let caseTransform = loc_keysDictionary[UITextField.case_titleKey]
-            self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
-        } else {
-            self.text = nil
-        }
-        
-        if let placeholder = placeholder {
-            let casePlaceholderTransform = loc_keysDictionary[UITextField.case_placeholderKey]
-            self.placeholder = placeholder.transform(with: I18nCaseTransform(rawValue: casePlaceholderTransform ?? ""))
-        } else {
-            self.placeholder = nil
-        }
-        
+        self.text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_titleKey] ?? ""))
+
+        self.placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_placeholderKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UITextField.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
@@ -25,14 +25,11 @@ extension UITextView: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let text = loc_keysDictionary[UITextView.loc_titleKey]?.localised else {
-            self.text  = ""
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UITextView.case_titleKey]
-        self.text = text.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextView.case_titleKey] ?? "")) ?? ""
+
+        self.accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised
     }
     
 }
-

--- a/SwiftI18n/Classes/Views/CaseViews/ViewController+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/ViewController+I18n_case.swift
@@ -25,13 +25,11 @@ extension UIViewController: I18n {
     }
     
     func loc_localeDidChange() {
-        guard let title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised else {
-            self.title = nil
-            return
-        }
-        
-        let caseTransform = loc_keysDictionary[UIViewController.case_titleKey]
-        self.title = title.transform(with: I18nCaseTransform(rawValue: caseTransform ?? ""))
+        self.title = loc_keysDictionary[UIViewController.loc_titleKey]?.localised
+            .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UIViewController.case_titleKey] ?? ""))
+
+        self.accessibilityLabel = loc_keysDictionary[UIViewController.loc_accessibilityLabelKey]?.localised
+        self.accessibilityHint = loc_keysDictionary[UIViewController.loc_accessibilityHintKey]?.localised
     }
     
 }


### PR DESCRIPTION
#### This PR adds support for changing the accessibility language on app language change

A scenario can happen where user has different language set in the iPhone settings and in the app. That can create unwanted behaviours when using VoiceOver, so I am setting `accessibilityLanguage` on `UIApplication` object inside the `language` setter, so that every time the app language is changed, VoiceOver will switch to that language.

More about this was said in the [discussion on Slack](https://infinum.slack.com/archives/C07UGAD8P4P/p1739280996512749)

I also propose a new 1.5.0 version of the library containing this change and the feature from https://github.com/infinum/ios-swiftI18n/pull/17