### PR TITLE
Fix/linter warnings

### DIFF
--- a/SwiftI18n.podspec
+++ b/SwiftI18n.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftI18n'
-  s.version          = '1.4.0'
+  s.version          = '1.5.0'
   s.summary          = 'I18n library for Swift'
   s.homepage         = 'https://github.com/infinum/ios-swiftI18n'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SwiftI18n/Classes/Main/I18n.swift
+++ b/SwiftI18n/Classes/Main/I18n.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol I18n: class {
+protocol I18n: AnyObject {
     func loc_localeDidChange()
 }
 

--- a/SwiftI18n/Classes/Main/I18nManager.swift
+++ b/SwiftI18n/Classes/Main/I18nManager.swift
@@ -47,6 +47,7 @@ public class I18nManager {
             _language = newValue
             UserDefaults.standard.set(newValue, forKey: .language)
             UserDefaults.standard.set([newValue], forKey: .appleLanguages)
+            UIApplication.shared.accessibilityLanguage = newValue
             NotificationCenter.default.post(name: .loc_LanguageDidChangeNotification, object: nil)
         }
         get {

--- a/SwiftI18n/Classes/Main/I18nManager.swift
+++ b/SwiftI18n/Classes/Main/I18nManager.swift
@@ -87,8 +87,8 @@ public extension I18nManager {
     /// - Returns: The localized string for the specified key and language, or the fallback language if the localization is not found.
     func localizedString(forKey key: String, language: String? = nil) -> String {
 
-        var localizedString = localizationPerformingBlock(key, language ?? self.language)
-        
+        let localizedString = localizationPerformingBlock(key, language ?? self.language)
+
         guard localizedString == key else {
             return localizedString
         }

--- a/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
@@ -8,14 +8,6 @@
 
 import UIKit
 
-extension UIControl.State: Hashable {
-    
-    public var hashValue: Int {
-        return Int(self.rawValue)
-    }
-    
-}
-
 public extension UIButton {
     
     @IBInspectable var locTitleKey: String? {
@@ -30,16 +22,14 @@ public extension UIButton {
     }
     
     func setLocTitleKey(_ key: String?, `for` state: UIControl.State) {
-        loc_keysDictionary[state] = key
+        loc_keysDictionary[state.rawValue] = key
     }
     
     func locTitleKey(`for` state: UIControl.State) -> String? {
-        return loc_keysDictionary[state]
+        return loc_keysDictionary[state.rawValue]
     }
     
     var loc_allStates: [UIControl.State] {
         return [.normal, .disabled, .highlighted, .selected]
     }
-    
 }
-

--- a/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
@@ -37,7 +37,7 @@ extension UIButton: I18n {
     }
     
     func loc_localeDidChange(`for` state: UIControl.State) {
-        guard let text = loc_keysDictionary[state]?.localised else {
+        guard let text = loc_keysDictionary[state.rawValue]?.localised else {
             setTitle(nil, for: state)
             return
         }


### PR DESCRIPTION
### This PR fixes a couple of small linter warnings

After running `pod lib lint` I saw a couple of linter warnings so I decided to make a few quick fixes for them. 

Most notably, there was a warning about `UIControl.State` conformance to `Hashable` protocol. The issue is that if Apple were to add this conformance, then we would have a problem since one type cannot conform to the same protocol twice. Even though this is an unlikely scenario, I though maybe there was no need for this conformance so I removed it and instead of putting `UIControl.State` objects as Dictionary keys i put their rawValue instead (which was used as the hash anyway). I tested it out manually and everything works as expected.