### PR TITLE
Add support for localized a11y labels on UIView

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		AB29FB8BB5EC40DC5D9292AEFF7BF6C8 /* String+I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2CF1A4D8985524A955F1402E74FD5B /* String+I18n.swift */; };
 		B04B1C5573BB822E7A5215873895CCDE /* Pods-SwiftI18n_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9498A7563F45DEA64DCBFF21844267A4 /* Pods-SwiftI18n_Tests-dummy.m */; };
 		B0BDBE454E9E0583B2B9CD0F574D33C6 /* ViewController+I18n_loc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B81B79C65CD93FD8B3D4A3CF8C269F9 /* ViewController+I18n_loc.swift */; };
+		B77B761F2D65D24B00FEACB3 /* UIView+I18n_loc.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77B761E2D65D24300FEACB3 /* UIView+I18n_loc.swift */; };
+		B77B76212D65D49400FEACB3 /* UIView+I18n_case.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77B76202D65D48C00FEACB3 /* UIView+I18n_case.swift */; };
 		BEA9CBB26E7AB3F5321A775305C4D827 /* UIBarButtonItem+I18n_loc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7726FF08DE2F2D69E45AF2317C6285A0 /* UIBarButtonItem+I18n_loc.swift */; };
 		C092AD12936B207993849BF35DD98914 /* UITextView+I18n_case.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1C8120CBBF7F38B0B8F6E295BA8C65 /* UITextView+I18n_case.swift */; };
 		CE7F1428DC2B22BD2DD1000DB48AB385 /* SwiftI18n-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CBDAF75AE4D9FBAA5E93DC7CC28B095C /* SwiftI18n-dummy.m */; };
@@ -100,6 +102,8 @@
 		A711B5DEFEE65C4123B27378B725A716 /* UIButton+I18n_loc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UIButton+I18n_loc.swift"; sourceTree = "<group>"; };
 		A78851D0C62FC19474427304E9CDCA1E /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		B46516C4DBBB15483A68C5FEB5816FC6 /* Pods-SwiftI18n_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SwiftI18n_Tests-umbrella.h"; sourceTree = "<group>"; };
+		B77B761E2D65D24300FEACB3 /* UIView+I18n_loc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+I18n_loc.swift"; sourceTree = "<group>"; };
+		B77B76202D65D48C00FEACB3 /* UIView+I18n_case.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+I18n_case.swift"; sourceTree = "<group>"; };
 		BCA90703C28E0D5BB9E0AF620CD5F57F /* UITextField+I18n_case.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UITextField+I18n_case.swift"; sourceTree = "<group>"; };
 		BF1C8120CBBF7F38B0B8F6E295BA8C65 /* UITextView+I18n_case.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UITextView+I18n_case.swift"; sourceTree = "<group>"; };
 		C0DCB9A258AF498F45156B24A159E97C /* Pods-SwiftI18n_Tests-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SwiftI18n_Tests-Info.plist"; sourceTree = "<group>"; };
@@ -169,6 +173,7 @@
 		5A27F860830BC1D3CAAEF76501026676 /* CaseViews */ = {
 			isa = PBXGroup;
 			children = (
+				B77B76202D65D48C00FEACB3 /* UIView+I18n_case.swift */,
 				57C8BC3EC20996C8E351AD62A89A7DF6 /* UIBarButtonItem+I18n_case.swift */,
 				19FAFCC823A6658606EF9DDC3DEACA13 /* UIButton+I18n_case.swift */,
 				268E02A2A07D1AA2544356A820308ED0 /* UILabel+I18n_case.swift */,
@@ -185,6 +190,7 @@
 		6A28F0B0DC9E202D489B80850E1B7215 /* BaseViews */ = {
 			isa = PBXGroup;
 			children = (
+				B77B761E2D65D24300FEACB3 /* UIView+I18n_loc.swift */,
 				7726FF08DE2F2D69E45AF2317C6285A0 /* UIBarButtonItem+I18n_loc.swift */,
 				A711B5DEFEE65C4123B27378B725A716 /* UIButton+I18n_loc.swift */,
 				28DD26D32BC9BDDD10191E82ABE27D69 /* UILabel+I18n_loc.swift */,
@@ -504,6 +510,7 @@
 				4968F10975AF93A59BBBC608CEBE3869 /* NSNotification+I18n.swift in Sources */,
 				AB29FB8BB5EC40DC5D9292AEFF7BF6C8 /* String+I18n.swift in Sources */,
 				CE7F1428DC2B22BD2DD1000DB48AB385 /* SwiftI18n-dummy.m in Sources */,
+				B77B76212D65D49400FEACB3 /* UIView+I18n_case.swift in Sources */,
 				414766CD2C382204DFEFA951CBA2ACDB /* UIBarButtonItem+I18n_case.swift in Sources */,
 				BEA9CBB26E7AB3F5321A775305C4D827 /* UIBarButtonItem+I18n_loc.swift in Sources */,
 				92BD70E97C6C9B9CD602A27A7845B916 /* UIButton+I18n_case.swift in Sources */,
@@ -513,6 +520,7 @@
 				0A782D088B4788200699D5BAFFE28796 /* UINavigationItem+I18n_case.swift in Sources */,
 				9D68EAD1DEDEA0539490398867BC37B6 /* UINavigationItem+I18n_loc.swift in Sources */,
 				824DD7EA16B745A37BA6634F8F96AFD5 /* UISearchBar+I18n_case.swift in Sources */,
+				B77B761F2D65D24B00FEACB3 /* UIView+I18n_loc.swift in Sources */,
 				26A256EC4505D81CDD1AA59D0D87BE69 /* UISearchBar+I18n_loc.swift in Sources */,
 				FBE0C1B103AB1728DB8D6311B59553F8 /* UITabBarItem+I18n_case.swift in Sources */,
 				31CB6DEE92AD5930BA536167B66022B8 /* UITabBarItem+I18n_loc.swift in Sources */,

--- a/SwiftI18n/Classes/Main/Localizable.swift
+++ b/SwiftI18n/Classes/Main/Localizable.swift
@@ -14,6 +14,9 @@ public struct Localizable<Base: LocKeyAcceptable> {
 
 public protocol LocKeyAcceptable: AnyObject {
     var locTitleKey: String? { get set }
+}
+
+public protocol AccessibilityLocKeyAcceptable: AnyObject {
     var locAccessibilityLabelKey: String? { get set }
     var locAccessibilityHintKey: String? { get set }
 }
@@ -25,12 +28,23 @@ public extension LocKeyAcceptable {
     }
 }
 
-extension UIBarButtonItem: LocKeyAcceptable {}
+// MARK: - Conforming views -
+
+// MARK: - UIView
+
+extension UIView: AccessibilityLocKeyAcceptable {}
+
+// MARK: - UIView subviews
+
 extension UILabel: LocKeyAcceptable {}
-extension UINavigationItem: LocKeyAcceptable {}
-extension UITabBarItem: LocKeyAcceptable {}
 extension UITextView: LocKeyAcceptable {}
 extension UIButton: LocKeyAcceptable {}
 extension UITextField: LocKeyAcceptable {}
-extension UIViewController: LocKeyAcceptable {}
 extension UISearchBar: LocKeyAcceptable {}
+
+// MARK: - Views that are not subviews of UIView
+
+extension UIBarButtonItem: LocKeyAcceptable & AccessibilityLocKeyAcceptable {}
+extension UINavigationItem: LocKeyAcceptable & AccessibilityLocKeyAcceptable {}
+extension UITabBarItem: LocKeyAcceptable & AccessibilityLocKeyAcceptable {}
+extension UIViewController: LocKeyAcceptable & AccessibilityLocKeyAcceptable {}

--- a/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
@@ -39,7 +39,7 @@ public extension UIButton {
         loc_keysDictionary[state]
     }
 
-    @IBInspectable var locAccessibilityLabelKey: String? {
+    @IBInspectable override var locAccessibilityLabelKey: String? {
         get {
             loc_keysDictionary[UIButton.loc_accessibilityLabelKey]
         }
@@ -49,7 +49,7 @@ public extension UIButton {
         }
     }
 
-    @IBInspectable var locAccessibilityHintKey: String? {
+    @IBInspectable override var locAccessibilityHintKey: String? {
         get {
             loc_keysDictionary[UIButton.loc_accessibilityHintKey]
         }

--- a/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIButton+I18n_loc.swift
@@ -18,9 +18,6 @@ extension UIControl.State: Hashable {
 
 public extension UIButton {
 
-    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
-    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
-
     @IBInspectable var locTitleKey: String? {
         get {
             locTitleKey(for: .normal)
@@ -37,26 +34,6 @@ public extension UIButton {
     
     func locTitleKey(`for` state: UIControl.State) -> String? {
         loc_keysDictionary[state]
-    }
-
-    @IBInspectable override var locAccessibilityLabelKey: String? {
-        get {
-            loc_keysDictionary[UIButton.loc_accessibilityLabelKey]
-        }
-        set {
-            loc_keysDictionary[UIButton.loc_accessibilityLabelKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityHintKey: String? {
-        get {
-            loc_keysDictionary[UIButton.loc_accessibilityHintKey]
-        }
-        set {
-            loc_keysDictionary[UIButton.loc_accessibilityHintKey] = newValue
-            loc_localeDidChange()
-        }
     }
 
     var loc_allStates: [UIControl.State] {

--- a/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
@@ -11,8 +11,6 @@ import UIKit
 public extension UILabel {
     
     static let loc_titleKey = "KEY"
-    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
-    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
 
     @IBInspectable var locTitleKey: String? {
         get {
@@ -20,26 +18,6 @@ public extension UILabel {
         }
         set(newValue) {
             loc_keysDictionary[UILabel.loc_titleKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityLabelKey: String? {
-        get {
-            loc_keysDictionary[UILabel.loc_accessibilityLabelKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UILabel.loc_accessibilityLabelKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityHintKey: String? {
-        get {
-            loc_keysDictionary[UILabel.loc_accessibilityHintKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UILabel.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UILabel+I18n_loc.swift
@@ -24,7 +24,7 @@ public extension UILabel {
         }
     }
 
-    @IBInspectable var locAccessibilityLabelKey: String? {
+    @IBInspectable override var locAccessibilityLabelKey: String? {
         get {
             loc_keysDictionary[UILabel.loc_accessibilityLabelKey]
         }
@@ -34,7 +34,7 @@ public extension UILabel {
         }
     }
 
-    @IBInspectable var locAccessibilityHintKey: String? {
+    @IBInspectable override var locAccessibilityHintKey: String? {
         get {
             loc_keysDictionary[UILabel.loc_accessibilityHintKey]
         }

--- a/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
@@ -11,8 +11,6 @@ public extension UISearchBar {
     
     static let loc_titleKey = "KEY"
     static let loc_placeholderKey = "PKEY"
-    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
-    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
 
     @IBInspectable var locTitleKey: String? {
         get {
@@ -30,26 +28,6 @@ public extension UISearchBar {
         }
         set(newValue) {
             loc_keysDictionary[UISearchBar.loc_placeholderKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityLabelKey: String? {
-        get {
-            loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityHintKey: String? {
-        get {
-            loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UISearchBar.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UISearchBar+I18n_loc.swift
@@ -34,7 +34,7 @@ public extension UISearchBar {
         }
     }
 
-    @IBInspectable var locAccessibilityLabelKey: String? {
+    @IBInspectable override var locAccessibilityLabelKey: String? {
         get {
             loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]
         }
@@ -44,7 +44,7 @@ public extension UISearchBar {
         }
     }
 
-    @IBInspectable var locAccessibilityHintKey: String? {
+    @IBInspectable override var locAccessibilityHintKey: String? {
         get {
             loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]
         }

--- a/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
@@ -12,8 +12,6 @@ public extension UITextField {
     
     static let loc_titleKey = "KEY"
     static let loc_placeholderKey = "PKEY"
-    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
-    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
 
     @IBInspectable var locTitleKey: String? {
         get {
@@ -31,26 +29,6 @@ public extension UITextField {
         }
         set(newValue) {
             loc_keysDictionary[UITextField.loc_placeholderKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityLabelKey: String? {
-        get {
-            loc_keysDictionary[UITextField.loc_accessibilityLabelKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UITextField.loc_accessibilityLabelKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityHintKey: String? {
-        get {
-            loc_keysDictionary[UITextField.loc_accessibilityHintKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UITextField.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextField+I18n_loc.swift
@@ -35,7 +35,7 @@ public extension UITextField {
         }
     }
 
-    @IBInspectable var locAccessibilityLabelKey: String? {
+    @IBInspectable override var locAccessibilityLabelKey: String? {
         get {
             loc_keysDictionary[UITextField.loc_accessibilityLabelKey]
         }
@@ -45,7 +45,7 @@ public extension UITextField {
         }
     }
 
-    @IBInspectable var locAccessibilityHintKey: String? {
+    @IBInspectable override var locAccessibilityHintKey: String? {
         get {
             loc_keysDictionary[UITextField.loc_accessibilityHintKey]
         }

--- a/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
@@ -24,7 +24,7 @@ public extension UITextView {
         }
     }
 
-    @IBInspectable var locAccessibilityLabelKey: String? {
+    @IBInspectable override var locAccessibilityLabelKey: String? {
         get {
             loc_keysDictionary[UITextView.loc_accessibilityLabelKey]
         }
@@ -34,7 +34,7 @@ public extension UITextView {
         }
     }
 
-    @IBInspectable var locAccessibilityHintKey: String? {
+    @IBInspectable override var locAccessibilityHintKey: String? {
         get {
             loc_keysDictionary[UITextView.loc_accessibilityHintKey]
         }

--- a/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UITextView+I18n_loc.swift
@@ -11,8 +11,6 @@ import UIKit
 public extension UITextView {
 
     static let loc_titleKey = "KEY"
-    static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
-    static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
 
     @IBInspectable var locTitleKey: String? {
         get {
@@ -20,26 +18,6 @@ public extension UITextView {
         }
         set(newValue) {
             loc_keysDictionary[UITextView.loc_titleKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityLabelKey: String? {
-        get {
-            loc_keysDictionary[UITextView.loc_accessibilityLabelKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UITextView.loc_accessibilityLabelKey] = newValue
-            loc_localeDidChange()
-        }
-    }
-
-    @IBInspectable override var locAccessibilityHintKey: String? {
-        get {
-            loc_keysDictionary[UITextView.loc_accessibilityHintKey]
-        }
-        set(newValue) {
-            loc_keysDictionary[UITextView.loc_accessibilityHintKey] = newValue
             loc_localeDidChange()
         }
     }

--- a/SwiftI18n/Classes/Views/BaseViews/UIView+I18n_loc.swift
+++ b/SwiftI18n/Classes/Views/BaseViews/UIView+I18n_loc.swift
@@ -1,0 +1,36 @@
+//
+//  UIView+I18n_loc.swift
+//  Pods
+//
+//  Created by Andrija Ostojic on 19.2.25..
+//
+
+import UIKit
+
+public extension UIView {
+
+    internal enum Constants {
+        static let loc_accessibilityLabelKey = "ACCESSIBILITY_LABEL_KEY"
+        static let loc_accessibilityHintKey = "ACCESSIBILITY_HINT_KEY"
+    }
+
+    @IBInspectable var locAccessibilityLabelKey: String? {
+        get {
+            loc_keysDictionary[Constants.loc_accessibilityLabelKey]
+        }
+        set(newValue) {
+            loc_keysDictionary[Constants.loc_accessibilityLabelKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+
+    @IBInspectable var locAccessibilityHintKey: String? {
+        get {
+            loc_keysDictionary[Constants.loc_accessibilityHintKey]
+        }
+        set(newValue) {
+            loc_keysDictionary[Constants.loc_accessibilityHintKey] = newValue
+            loc_localeDidChange()
+        }
+    }
+}

--- a/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
@@ -31,9 +31,8 @@ extension UIButton {
     }
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
-        accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
     }
     
     func loc_localeDidChange(`for` state: UIControl.State) {

--- a/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIButton+I18n_case.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension UIButton: I18n {
+extension UIButton {
     
     private static let case_titleKey = "CKEY"
     
@@ -30,7 +30,7 @@ extension UIButton: I18n {
         return I18nCaseTransform(rawValue: loc_keysDictionary["\(state)\(UIButton.case_titleKey)"] ?? "")
     }
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
         accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
         accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised

--- a/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension UILabel: I18n {
+extension UILabel {
     
     private static let case_titleKey = "CKEY"
     
@@ -22,7 +22,7 @@ extension UILabel: I18n {
         }
     }
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UILabel.case_titleKey] ?? ""))
         accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised

--- a/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UILabel+I18n_case.swift
@@ -23,9 +23,8 @@ extension UILabel {
     }
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UILabel.case_titleKey] ?? ""))
-        accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised
     }
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
@@ -33,11 +33,10 @@ extension UISearchBar {
     }
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_titleKey] ?? ""))
         placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_placeholderKey] ?? ""))
-        accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]?.localised
     }
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UISearchBar+I18n_case.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-extension UISearchBar: I18n {
+extension UISearchBar {
     
     private static let case_titleKey = "CKEY"
     private static let case_placeholderKey = "CPKEY"
@@ -32,7 +32,7 @@ extension UISearchBar: I18n {
         }
     }
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UISearchBar.case_titleKey] ?? ""))
         placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised

--- a/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
@@ -34,11 +34,10 @@ extension UITextField {
     }
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_titleKey] ?? ""))
         placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_placeholderKey] ?? ""))
-        accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UITextField.loc_accessibilityHintKey]?.localised
     }
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextField+I18n_case.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension UITextField: I18n {
+extension UITextField {
     
     private static let case_titleKey = "CKEY"
     private static let case_placeholderKey = "CPKEY"
@@ -33,7 +33,7 @@ extension UITextField: I18n {
         }
     }
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextField.case_titleKey] ?? ""))
         placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised

--- a/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension UITextView: I18n {
+extension UITextView {
     
     private static let case_titleKey = "CKEY"
     
@@ -22,7 +22,7 @@ extension UITextView: I18n {
         }
     }
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextView.case_titleKey] ?? "")) ?? ""
 

--- a/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UITextView+I18n_case.swift
@@ -23,10 +23,8 @@ extension UITextView {
     }
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
             .transform(with: I18nCaseTransform(rawValue: loc_keysDictionary[UITextView.case_titleKey] ?? "")) ?? ""
-
-        accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised
     }
 }

--- a/SwiftI18n/Classes/Views/CaseViews/UIView+I18n_case.swift
+++ b/SwiftI18n/Classes/Views/CaseViews/UIView+I18n_case.swift
@@ -1,0 +1,17 @@
+//
+//  UIView+I18n_case.swift
+//  Pods
+//
+//  Created by Andrija Ostojic on 19.2.25..
+//
+
+import UIKit
+
+extension UIView: I18n {
+
+    @objc func loc_localeDidChange() {
+        accessibilityLabel = loc_keysDictionary[Constants.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[Constants.loc_accessibilityHintKey]?.localised
+    }
+}
+

--- a/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
@@ -10,13 +10,12 @@ import UIKit
 
 extension UIButton {
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
-        accessibilityLabel = loc_keysDictionary[UIButton.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
     }
     
-    override func loc_localeDidChange(`for` state: UIControl.State) {
+    func loc_localeDidChange(`for` state: UIControl.State) {
         guard let text = loc_keysDictionary[state]?.localised  else { return }
         setTitle(text, for: state)
     }

--- a/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension UIButton: I18n {
+extension UIButton {
     
     func loc_localeDidChange() {
         loc_allStates.forEach { loc_localeDidChange(for: $0) }
@@ -16,10 +16,9 @@ extension UIButton: I18n {
         accessibilityHint = loc_keysDictionary[UIButton.loc_accessibilityHintKey]?.localised
     }
     
-    func loc_localeDidChange(`for` state: UIControl.State) {
+    override func loc_localeDidChange(`for` state: UIControl.State) {
         guard let text = loc_keysDictionary[state]?.localised  else { return }
         setTitle(text, for: state)
     }
-    
 }
 

--- a/SwiftI18n/Classes/Views/PlainViews/UILabel+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UILabel+I18n.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-extension UILabel: I18n {
+extension UILabel {
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
         accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
         accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised

--- a/SwiftI18n/Classes/Views/PlainViews/UILabel+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UILabel+I18n.swift
@@ -11,9 +11,8 @@ import UIKit
 extension UILabel {
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UILabel.loc_titleKey]?.localised
-        accessibilityLabel = loc_keysDictionary[UILabel.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UILabel.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
@@ -10,10 +10,8 @@ import UIKit
 extension UISearchBar {
 
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
         placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
-        accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UISearchBar.loc_accessibilityHintKey]?.localised
     }
-
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UISearchBar+I18n.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-extension UISearchBar: I18n {
+extension UISearchBar {
 
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UISearchBar.loc_titleKey]?.localised
         placeholder = loc_keysDictionary[UISearchBar.loc_placeholderKey]?.localised
         accessibilityLabel = loc_keysDictionary[UISearchBar.loc_accessibilityLabelKey]?.localised

--- a/SwiftI18n/Classes/Views/PlainViews/UITextField+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITextField+I18n.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-extension UITextField: I18n {
+extension UITextField {
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
         placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
         accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised

--- a/SwiftI18n/Classes/Views/PlainViews/UITextField+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITextField+I18n.swift
@@ -11,10 +11,9 @@ import UIKit
 extension UITextField {
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UITextField.loc_titleKey]?.localised
         placeholder = loc_keysDictionary[UITextField.loc_placeholderKey]?.localised
-        accessibilityLabel = loc_keysDictionary[UITextField.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UITextField.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UITextView+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITextView+I18n.swift
@@ -11,9 +11,8 @@ import UIKit
 extension UITextView {
     
     override func loc_localeDidChange() {
+        super.loc_localeDidChange()
         text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
-        accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
-        accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised
     }
     
 }

--- a/SwiftI18n/Classes/Views/PlainViews/UITextView+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UITextView+I18n.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-extension UITextView: I18n {
+extension UITextView {
     
-    func loc_localeDidChange() {
+    override func loc_localeDidChange() {
         text = loc_keysDictionary[UITextView.loc_titleKey]?.localised
         accessibilityLabel = loc_keysDictionary[UITextView.loc_accessibilityLabelKey]?.localised
         accessibilityHint = loc_keysDictionary[UITextView.loc_accessibilityHintKey]?.localised

--- a/SwiftI18n/Classes/Views/PlainViews/UIView+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UIView+I18n.swift
@@ -1,0 +1,17 @@
+//
+//  UILabel+I18n.swift
+//  SwiftI18n
+//
+//  Created by Vlaho Poluta on 17/08/16.
+//  Copyright © 2016 Infinum. All rights reserved.
+//
+
+import UIKit
+
+extension UIView: I18n {
+
+    @objc func loc_localeDidChange() {
+        accessibilityLabel = loc_keysDictionary[Constants.loc_accessibilityLabelKey]?.localised
+        accessibilityHint = loc_keysDictionary[Constants.loc_accessibilityHintKey]?.localised
+    }
+}


### PR DESCRIPTION
### This PR is a proposal to add support for localized a11y label on UIView class

Since UIView is an empty view, it had no sense to add any kind of localized label on it, because it has nothing written on it. But, even though UIView does not have any visible text on it, there is a case where we might want to put an accessibility label or hint on it. For example when we are using that UIView as a container for other elements and we want to give that container a label that VoiceOver can read. I encountered a couple of cases like that in my project.

Adding this support seemed tricky at first, mostly because of inheritance where a lot the views that already support localized text via Swift-I18n are inheriting from UIView (UIButton, UILabel). But I think I found a neat way to manage that.

So, here I will list the changes I made to make them more comprehensive:
- I added another protocol `AccessibilityLocKeyAcceptable` which has a11y label and hint as requirement. My motivation for this was the fact that `UIView` only had to adopt this protocol and not `LocKeyAcceptable`. Basically I separated `LocKeyAcceptable` into two protocols, where `UIView` only implements `AccessibilityLocKeyAcceptable` and all the other views implement both
- I had to annotate `loc_localeDidChange` func in `UIView` with `@objc` because otherwise I couldn't override it in the views inheriting from UIView, and I needed to override it.
- Also `locAccessibilityLabelKey ` and `locAccessibilityHintKey ` are now overrides, but only in the views that inherit from `UIView` (for example, `UIBarButtonItem` or `UITabBarItem` don't)
- I created an `internal enum Constants` inside `UIView` in order to put the keys for a11y label and hint inside it, because if they were to stay as static properties on the class, that would class with the static properties from the views inheriting from `UIView`. 