### PR TITLE
Adds support for init accepting LocText in SwiftUI views

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3131D0EE3E90BC4400A1526A8E60C99C /* UITabBarItem+I18n_loc.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4C1D7A30A3CE34E40D090D0CFCC7936 /* UITabBarItem+I18n_loc.swift */; };
 		3259B99B970DB13B35F7F5356DCEE9B2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 384DDA2CB25005BD6479B5987C619DD4 /* Foundation.framework */; };
 		3C0875081A6FD2342ADF8F7270F253FB /* UITextField+I18n_loc.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FF99D8D54B29295662D079D73B1696C /* UITextField+I18n_loc.swift */; };
+		42A699292E45D46B0012347E /* LocTextViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42A699282E45D4690012347E /* LocTextViewExtensions.swift */; };
 		4B49BC600D7556936AE3A3CB5B353D1F /* UIButton+I18n_case.swift in Sources */ = {isa = PBXBuildFile; fileRef = D26B5373FAA013B8FF7015F7694A7D82 /* UIButton+I18n_case.swift */; };
 		4CBD29C86C50687F3DC68165AD6DE881 /* Pods-SwiftI18n_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9498A7563F45DEA64DCBFF21844267A4 /* Pods-SwiftI18n_Tests-dummy.m */; };
 		548171C127C72F08BC75C1FFC1D6296A /* SwiftI18n-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FA5F860E4729C3AD89C5DEE1D599A72C /* SwiftI18n-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -93,6 +94,7 @@
 		384DDA2CB25005BD6479B5987C619DD4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		39C255A3549AB8BC2B51D2A661F9DF6B /* UITabBarItem+I18n_case.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UITabBarItem+I18n_case.swift"; sourceTree = "<group>"; };
 		4104D5B0647036ECCD2299DAB381F5D6 /* UINavigationItem+I18n_loc.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+I18n_loc.swift"; sourceTree = "<group>"; };
+		42A699282E45D4690012347E /* LocTextViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocTextViewExtensions.swift; sourceTree = "<group>"; };
 		444C15644243F525B275565549A2CE0C /* I18n.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		44550AE925EE1BA62271129B033D77C4 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		471802C13CCA684411A556859A7F3E75 /* Pods-SwiftI18n_Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SwiftI18n_Example-acknowledgements.plist"; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 		B39158A33BE6E77537C0E47442E58EF6 /* SwiftUI */ = {
 			isa = PBXGroup;
 			children = (
+				42A699282E45D4690012347E /* LocTextViewExtensions.swift */,
 				B76CC5272E44BBA100072E9D /* AccessibilityModifiers.swift */,
 				B76CC5252E44BB7900072E9D /* LanguageModifier.swift */,
 				1B5A0AE1DCFC4CFE08976D6E7F31DBC8 /* LocText.swift */,
@@ -590,6 +593,7 @@
 				CFB8BFB11CC5546BC049A51384914076 /* I18nCaseI18nCaseTransform.swift in Sources */,
 				74107C9E10F801BEECBBB91BA8E84A05 /* I18nCaseTransformable.swift in Sources */,
 				CFACFBAF752B71A583B68C7C5EA5BD32 /* I18nManager.swift in Sources */,
+				42A699292E45D46B0012347E /* LocTextViewExtensions.swift in Sources */,
 				B76CC5262E44BB7C00072E9D /* LanguageModifier.swift in Sources */,
 				E3BB4B611D98FFFAC610F40651C73FED /* Localizable.swift in Sources */,
 				998004833E8AE196872278D8AE81E6C8 /* LocText.swift in Sources */,

--- a/Example/SwiftI18n/LocalizedStrings/en.lproj/en.strings
+++ b/Example/SwiftI18n/LocalizedStrings/en.lproj/en.strings
@@ -23,3 +23,5 @@
 "text_field_example_placeholder" = "This is some placeholder text";
 "text_view_title" = "Text view";
 "text_view_example" = "This is a text view";
+"useless_button_hint" = "This button does nothing";
+"useless_button_label" = "Nothing";

--- a/Example/SwiftI18n/LocalizedStrings/en.lproj/hr.strings
+++ b/Example/SwiftI18n/LocalizedStrings/en.lproj/hr.strings
@@ -22,3 +22,5 @@
 "text_field_example_placeholder" = "Popunite tekstualno polje";
 "text_view_title" = "Tekstualno mega polje";
 "text_view_example" = "Ovo je tekstualno mega polje";
+"useless_button_hint" = "Ovo dugme ne radi ništa";
+"useless_button_label" = "Ništa";

--- a/Example/SwiftI18n/UI/SwiftUI Example/SwiftUIExampleView.swift
+++ b/Example/SwiftI18n/UI/SwiftUI Example/SwiftUIExampleView.swift
@@ -24,13 +24,13 @@ struct SwiftUIExampleView: View {
                 LocText("button_example")
                     .font(.headline)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Button(action: { }) {
-                    LocText("useless_button")
-                        .padding(EdgeInsets(top: 12, leading: 32, bottom: 12, trailing: 32))
-                        .background(Color.blue)
-                        .foregroundStyle(Color.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
+                Button(locTitleKey: "useless_button") {}
+                    .padding(EdgeInsets(top: 12, leading: 32, bottom: 12, trailing: 32))
+                    .background(Color.blue)
+                    .foregroundStyle(Color.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .setAccessibilityHint(key: "useless_button_hint")
+                    .setAccessibilityLabel(key: "useless_button_label")
                 Spacer()
             }
             .padding(EdgeInsets(top: 32, leading: 16, bottom: 32, trailing: 16))

--- a/SwiftI18n/Classes/Views/SwiftUI/LocTextViewExtensions.swift
+++ b/SwiftI18n/Classes/Views/SwiftUI/LocTextViewExtensions.swift
@@ -1,0 +1,103 @@
+//
+//  LocTextViewExtensions.swift
+//  Pods
+//
+//  Created by Milos on 8. 8. 2025..
+//
+
+import SwiftUI
+
+// MARK: - Menu -
+
+@available(iOS 14.0, *)
+public extension Menu where Label == LocText {
+    init(key: String, @ViewBuilder content: @escaping () -> Content) {
+        self.init {
+            content()
+        } label: {
+            LocText(key)
+        }
+    }
+}
+
+// MARK: - Button -
+
+public extension Button where Label == LocText {
+    init(key: String, action: @escaping () -> Void) {
+        self.init(action: action) {
+            LocText(key)
+        }
+    }
+
+    @available(iOS 15.0, *)
+    init(role: ButtonRole?, key: String, action: @escaping () -> Void) {
+        self.init(role: role, action: action) {
+            LocText(key)
+        }
+    }
+}
+
+// MARK: - Label -
+
+@available(iOS 14.0, *)
+public extension Label where Title == LocText, Icon == EmptyView {
+    init(key: String) {
+        self.init {
+            LocText(key)
+        } icon: {
+            EmptyView()
+        }
+    }
+}
+
+@available(iOS 14.0, *)
+public extension Label where Title == LocText, Icon == Image {
+    init(key: String, systemImage: String) {
+        self.init {
+            LocText(key)
+        } icon: {
+            Image(systemName: systemImage)
+        }
+    }
+
+    init(key: String, image: String) {
+        self.init {
+            LocText(key)
+        } icon: {
+            Image(image)
+        }
+    }
+}
+
+// MARK: - Toggle -
+
+public extension Toggle where Label == LocText {
+    init(isOn: Binding<Bool>, key: String) {
+        self.init(isOn: isOn) {
+            LocText(key)
+        }
+    }
+}
+
+// MARK: - TextField -
+
+@available(iOS 15.0, *)
+public extension TextField where Label == LocText {
+    init(text: Binding<String>, placeholder: String) {
+        self.init(text: text) {
+            LocText(placeholder)
+        }
+    }
+
+    init(text: Binding<String>, formatter: Formatter, placeholder: String) {
+        self.init(value: text, formatter: formatter) {
+            LocText(placeholder)
+        }
+    }
+
+    init<F>(_ value: Binding<F.FormatInput?>, format: F, placeholder: String) where F : ParseableFormatStyle, F.FormatOutput == String {
+        self.init(value: value, format: format) {
+            LocText(placeholder)
+        }
+    }
+}

--- a/SwiftI18n/Classes/Views/SwiftUI/LocTextViewExtensions.swift
+++ b/SwiftI18n/Classes/Views/SwiftUI/LocTextViewExtensions.swift
@@ -11,11 +11,11 @@ import SwiftUI
 
 @available(iOS 14.0, *)
 public extension Menu where Label == LocText {
-    init(key: String, @ViewBuilder content: @escaping () -> Content) {
+    init(locTitleKey: String, @ViewBuilder content: @escaping () -> Content) {
         self.init {
             content()
         } label: {
-            LocText(key)
+            LocText(locTitleKey)
         }
     }
 }
@@ -23,16 +23,16 @@ public extension Menu where Label == LocText {
 // MARK: - Button -
 
 public extension Button where Label == LocText {
-    init(key: String, action: @escaping () -> Void) {
+    init(locTitleKey: String, action: @escaping () -> Void) {
         self.init(action: action) {
-            LocText(key)
+            LocText(locTitleKey)
         }
     }
 
     @available(iOS 15.0, *)
-    init(role: ButtonRole?, key: String, action: @escaping () -> Void) {
+    init(role: ButtonRole?, locTitleKey: String, action: @escaping () -> Void) {
         self.init(role: role, action: action) {
-            LocText(key)
+            LocText(locTitleKey)
         }
     }
 }
@@ -41,9 +41,9 @@ public extension Button where Label == LocText {
 
 @available(iOS 14.0, *)
 public extension Label where Title == LocText, Icon == EmptyView {
-    init(key: String) {
+    init(locTitleKey: String) {
         self.init {
-            LocText(key)
+            LocText(locTitleKey)
         } icon: {
             EmptyView()
         }
@@ -52,17 +52,17 @@ public extension Label where Title == LocText, Icon == EmptyView {
 
 @available(iOS 14.0, *)
 public extension Label where Title == LocText, Icon == Image {
-    init(key: String, systemImage: String) {
+    init(locTitleKey: String, systemImage: String) {
         self.init {
-            LocText(key)
+            LocText(locTitleKey)
         } icon: {
             Image(systemName: systemImage)
         }
     }
 
-    init(key: String, image: String) {
+    init(locTitleKey: String, image: String) {
         self.init {
-            LocText(key)
+            LocText(locTitleKey)
         } icon: {
             Image(image)
         }
@@ -72,9 +72,9 @@ public extension Label where Title == LocText, Icon == Image {
 // MARK: - Toggle -
 
 public extension Toggle where Label == LocText {
-    init(isOn: Binding<Bool>, key: String) {
+    init(isOn: Binding<Bool>, locTitleKey: String) {
         self.init(isOn: isOn) {
-            LocText(key)
+            LocText(locTitleKey)
         }
     }
 }
@@ -83,21 +83,21 @@ public extension Toggle where Label == LocText {
 
 @available(iOS 15.0, *)
 public extension TextField where Label == LocText {
-    init(text: Binding<String>, placeholder: String) {
+    init(text: Binding<String>, locPlaceholderKey: String) {
         self.init(text: text) {
-            LocText(placeholder)
+            LocText(locPlaceholderKey)
         }
     }
 
-    init(text: Binding<String>, formatter: Formatter, placeholder: String) {
+    init(text: Binding<String>, formatter: Formatter, locPlaceholderKey: String) {
         self.init(value: text, formatter: formatter) {
-            LocText(placeholder)
+            LocText(locPlaceholderKey)
         }
     }
 
-    init<F>(_ value: Binding<F.FormatInput?>, format: F, placeholder: String) where F : ParseableFormatStyle, F.FormatOutput == String {
+    init<F>(_ value: Binding<F.FormatInput?>, format: F, locPlaceholderKey: String) where F : ParseableFormatStyle, F.FormatOutput == String {
         self.init(value: value, format: format) {
-            LocText(placeholder)
+            LocText(locPlaceholderKey)
         }
     }
 }


### PR DESCRIPTION
## Summary

Adding support for initialising SwiftUI views using locTitleKey as a parameter and using LocText in the init body. Support added for Menu, Button, Label, Toggle, TextField.

**Related issue**: [JIRA ticket](https://app.productive.io/1-infinum/tasks/task/11263247?filter=LTE%3D)


### Type

- [x] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

### Description

Public extensions are created for each of the mentioned SwiftUi views that accept give locTextKey and use in inside their Init body with LocText.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

This can be tested in the example project and one Button is created there using this init as an example