### PR TITLE
Fix an error caused by removed UIControl.State's conformance to Hashable

### DIFF
--- a/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
+++ b/SwiftI18n/Classes/Views/PlainViews/UIButton+I18n.swift
@@ -16,7 +16,7 @@ extension UIButton {
     }
     
     func loc_localeDidChange(`for` state: UIControl.State) {
-        guard let text = loc_keysDictionary[state]?.localised  else { return }
+        guard let text = loc_keysDictionary[state.rawValue]?.localised  else { return }
         setTitle(text, for: state)
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes an error discovered when running `pod lib lint` where since `UIControl.State` conformance to `Hashable` was removed in one of the PRs because there was a Swiftlint error, now you can't directly pass a `UIControl.State` to `loc_keysDictionary` but you have to use it's `rawValue` instead. That was fixed for `BaseViews`, but not for `PlainViews`
<!-- 
    Provide an overview of what this pull request aims to address or achieve.
-->

**Related issue**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->