### PR TITLE
Fix/handle app extension

### DIFF
--- a/SwiftI18n.podspec
+++ b/SwiftI18n.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftI18n'
-  s.version          = '2.0.0'
+  s.version          = '2.0.1'
   s.summary          = 'I18n library for Swift'
   s.homepage         = 'https://github.com/infinum/ios-swiftI18n'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/SwiftI18n/Classes/Main/I18nManager.swift
+++ b/SwiftI18n/Classes/Main/I18nManager.swift
@@ -48,8 +48,10 @@ public class I18nManager {
             _language = newValue
             UserDefaults.standard.set(newValue, forKey: .language)
             UserDefaults.standard.set([newValue], forKey: .appleLanguages)
-            UIApplication.shared.accessibilityLanguage = newValue
             NotificationCenter.default.post(name: .loc_LanguageDidChangeNotification, object: nil)
+            #if APP_EXTENSION
+            UIApplication.shared.accessibilityLanguage = newValue
+            #endif
         }
         get {
             if let language = _language {


### PR DESCRIPTION
## Summary
This PR fixes an issue that appears when using the library in App Extensions, because the library is accessing `UIApplication.shared` which is not permitted from an App Extension.
<!-- 
    Provide an overview of what this pull request aims to address or achieve.
-->

**Related issue**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- I resolved the issue by wrapping the problematic piece of code inside `#if APP_EXTENSION`.
Notice that there is no `!` sign in front of `APP_EXTENSION` which should be the case intuitively, but after some research and testing we found out that this macro actually means that we are NOT in an app extension :)

    - Before Swift even existed, Xcode’s build system and Apple’s Clang compiler used a C preprocessor macro called APP_EXTENSION. Now it can't be changed because of ABI stability.
    - APP_EXTENSION means “this code is being compiled in a context where app extensions exist (i.e., an app)“, not “this code is an app extension.”
    - This came from the Objective-C and C++ world — the Clang driver defines it inversely to prevent linking unsafe APIs into app extensions.
- I bumped the version to 2.0.1 too

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes
None
<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->