### PR TITLE
Fix missing override for localization performing block

### DIFF
--- a/SwiftI18n/Classes/Main/I18nManager.swift
+++ b/SwiftI18n/Classes/Main/I18nManager.swift
@@ -37,11 +37,17 @@ public class I18nManager {
     ///
     /// Setting `fallbackLanguage` should be done with consideration of these potential overrides
     public var fallbackLanguage: String?
-    
-    public func localizationPerformingBlock(_ key: String, _ language: String, _ bundle: Bundle = .main) -> (String) {
-        NSLocalizedString(key, tableName: language, bundle: bundle, comment: "")
-    }
 
+    /// Optional closure that overrides the default localization lookup.
+    /// Use this to provide project-specific localization logic instead of the standard `NSLocalizedString` lookup.
+    public var localizationPerformingCustomBlock: ((_ key: String, _ language: String, _ bundle: Bundle) -> (String))?
+
+    /// Returns a localized string for the given key and language.
+    /// If ``localizationPerformingCustomBlock`` is set, it delegates to that closure, otherwise falls back to `NSLocalizedString`
+    public func localizationPerformingBlock(_ key: String, _ language: String, _ bundle: Bundle = .main) -> (String) {
+        localizationPerformingCustomBlock?(key, language, bundle) ?? NSLocalizedString(key, tableName: language, bundle: bundle, comment: "")
+    }
+    
     private var _language: String?
     public var language: String {
         set(newValue) {


### PR DESCRIPTION
## Summary
This PR fixes a bug where in the latest release when changing `localizationPerformingBlock` from `var` to `func` opportunity to override this block was taken away. Now it's restored by adding a new property `localizationPerformingCustomBlock`. If this property is set it takes precedence over the default implementation.
<!-- 
    Provide an overview of what this pull request aims to address or achieve.
-->

**Related issue**: <!-- Add the issue number in format [#<number>](link) or set to "None" if this is not related to a reported issue. -->

## Changes

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [x] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [x] **Documentation**: This pull request updates documentation.
- [ ] **Other**: This pull request makes other changes.

#### Additional information

- [ ] This pull request introduces a **breaking change**.

### Description

<!-- 
    Describe the specific changes made in this pull request, including any technical details or architectural decisions. 

    If applicable, include additional information like screenshots, logs or other data that demonstrate the changes. 
-->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes
With this fix we should be ready to publish a 2.0.1 release
<!-- 
    Add any additional comments, instructions, or insights about this pull request. 
-->